### PR TITLE
Update doc to remind submodule clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Java bindings for [tree-sitter](https://tree-sitter.github.io/tree-sitter/).
 
+## Preparing
+
+Recursively clone the project with submodules:
+
+    git clone https://github.com/serenadeai/java-tree-sitter.git --recursive
+    
+Or clone first and update the submodules then:
+   
+    git clone https://github.com/serenadeai/java-tree-sitter.git
+    git submodule update --init --recursive  
+    # or:  git submodule init && git submodule update
+
+
 ## Building
 
 Before you can start using java-tree-sitter, you need to build a shared library that Java can load. The included `build.py` script can facilitate building the library. The first argument is the output file, followed by all of the tree-sitter repositories that you want to be included:

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ Java bindings for [tree-sitter](https://tree-sitter.github.io/tree-sitter/).
 
 Recursively clone the project with submodules:
 
-    git clone https://github.com/serenadeai/java-tree-sitter.git --recursive
-    
+```shell
+git clone https://github.com/serenadeai/java-tree-sitter.git --recursive
+```
+
 Or clone first and update the submodules then:
-   
-    git clone https://github.com/serenadeai/java-tree-sitter.git
-    git submodule update --init --recursive  
-    # or:  git submodule init && git submodule update
+
+```shell   
+git clone https://github.com/serenadeai/java-tree-sitter.git
+git submodule update --init --recursive  
+# or:  git submodule init && git submodule update
+```
 
 ## Installing
 


### PR DESCRIPTION
To avoid such error:

```
make: *** No targets specified and no makefile found.  Stop.
/Users/symbolk/coding/analysis/java-tree-sitter/lib/ai_serenade_treesitter_TreeSitter.cc:5:10: fatal error:
      'tree_sitter/api.h' file not found
#include <tree_sitter/api.h>
         ^~~~~~~~~~~~~~~~~~~
1 error generated.
Traceback (most recent call last):
  File "/Users/symbolk/.pyenv/versions/3.7.0/lib/python3.7/distutils/unixccompiler.py", line 118, in _compile
    extra_postargs)
  File "/Users/symbolk/.pyenv/versions/3.7.0/lib/python3.7/distutils/ccompiler.py", line 909, in spawn
    spawn(cmd, dry_run=self.dry_run)
  File "/Users/symbolk/.pyenv/versions/3.7.0/lib/python3.7/distutils/spawn.py", line 36, in spawn
    _spawn_posix(cmd, search_path, dry_run=dry_run)
  File "/Users/symbolk/.pyenv/versions/3.7.0/lib/python3.7/distutils/spawn.py", line 159, in _spawn_posix
    % (cmd, exit_status))
distutils.errors.DistutilsExecError: command 'cc' failed with exit status 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./build.py", line 115, in <module>
    build(sys.argv[2:], sys.argv[1])
  File "./build.py", line 88, in build
    extra_preargs=flags,
  File "/Users/symbolk/.pyenv/versions/3.7.0/lib/python3.7/distutils/ccompiler.py", line 574, in compile
    self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
  File "/Users/symbolk/.pyenv/versions/3.7.0/lib/python3.7/distutils/unixccompiler.py", line 120, in _compile
    raise CompileError(msg)
distutils.errors.CompileError: command 'cc' failed with exit status 1
```