### PR TITLE
Add binding to method hasError of class Node

### DIFF
--- a/lib/ai_serenade_treesitter_TreeSitter.cc
+++ b/lib/ai_serenade_treesitter_TreeSitter.cc
@@ -117,6 +117,12 @@ JNIEXPORT jint JNICALL Java_ai_serenade_treesitter_TreeSitter_nodeChildCount(
   return (jint)ts_node_child_count(_unmarshalNode(env, node));
 }
 
+JNIEXPORT jboolean JNICALL Java_ai_serenade_treesitter_TreeSitter_nodeHasError(
+    JNIEnv* env, jclass self, jobject node) {
+    // use conditional to avoid conversion from bool to jboolean (unsigned char)
+    return ts_node_has_error(_unmarshalNode(env, node)) ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT jstring JNICALL Java_ai_serenade_treesitter_TreeSitter_nodeString(
     JNIEnv* env, jclass self, jobject node) {
   char* nodeString = ts_node_string(_unmarshalNode(env, node));

--- a/lib/ai_serenade_treesitter_TreeSitter.h
+++ b/lib/ai_serenade_treesitter_TreeSitter.h
@@ -25,6 +25,14 @@ JNIEXPORT jint JNICALL Java_ai_serenade_treesitter_TreeSitter_nodeChildCount
 
 /*
  * Class:     ai_serenade_treesitter_TreeSitter
+ * Method:    nodeHasError
+ * Signature: (Lai/serenade/treesitter/Node;)I
+ */
+JNIEXPORT jboolean JNICALL Java_ai_serenade_treesitter_TreeSitter_nodeHasError
+  (JNIEnv *, jclass, jobject);
+
+/*
+ * Class:     ai_serenade_treesitter_TreeSitter
  * Method:    nodeEndByte
  * Signature: (Lai/serenade/treesitter/Node;)I
  */

--- a/src/main/java/ai/serenade/treesitter/Node.java
+++ b/src/main/java/ai/serenade/treesitter/Node.java
@@ -18,6 +18,10 @@ public class Node {
     return TreeSitter.nodeChildCount(this);
   }
 
+  public boolean hasError() {
+    return TreeSitter.nodeHasError(this);
+  }
+
   public int getEndByte() {
     return TreeSitter.nodeEndByte(this);
   }

--- a/src/main/java/ai/serenade/treesitter/TreeSitter.java
+++ b/src/main/java/ai/serenade/treesitter/TreeSitter.java
@@ -6,6 +6,8 @@ public class TreeSitter {
 
   public static native int nodeChildCount(Node node);
 
+  public static native boolean nodeHasError(Node node);
+
   public static native int nodeEndByte(Node node);
 
   public static native int nodeStartByte(Node node);

--- a/src/test/java/ai/serenade/treesitter/NodeTest.java
+++ b/src/test/java/ai/serenade/treesitter/NodeTest.java
@@ -24,4 +24,15 @@ public class NodeTest extends TestBase {
       }
     }
   }
+
+  @Test
+  void testGetChildren() throws UnsupportedEncodingException {
+    try (Parser parser = new Parser()) {
+      parser.setLanguage(Languages.python());
+      try (Tree tree = parser.parseString("def foo(bar baz)\n  print(bar,)\n  print(baz)")) {
+        Node root = tree.getRootNode();
+        assert(root.hasError());
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR adds a binding to the `ts_node_has_error` tree-sitter function to determine if a tree node has any syntax errors in its subtree. This is important to quickly determine if parsing has encountered an error without having to traverse the tree. 