### PR TITLE
Fix build.py issue when directory contains spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dependencies {
 
 Before you can start using java-tree-sitter, you need to build a shared library that Java can load using the `build.py` script. The first argument is the output file (_libjava-tree-sitter_ by default), followed by all of the tree-sitter repositories (already downloaded) that you want to include:
 
-```bash
+```shell
 ./build.py -o libjava-tree-sitter path-to-tree-sitter-css path-to-tree-sitter-python ...
 ```
 
@@ -77,7 +77,7 @@ try (Parser parser = new Parser()) {
 
 For debugging, it can be helpful to see a string of the tree:
 
-```
+```java
 try (Parser parser = new Parser()) {
   parser.setLanguage(Languages.python());
   try (Tree tree = parser.parseString("print(\"hi\")")) {
@@ -91,7 +91,7 @@ try (Parser parser = new Parser()) {
 
 If you're going to be traversing a tree, then you can use the `walk` method, which is much more efficient than the above getters:
 
-```
+```java
 try (Parser parser = new Parser()) {
   parser.setLanguage(Languages.python());
   try (Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)")) {

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ To add this library to a Gradle project:
 
 ## Building
 
-Before you can start using java-tree-sitter, you need to build a shared library that Java can load. The included `build.py` script can facilitate building the library. The first argument is the output file, followed by all of the tree-sitter repositories that you want to be included:
+Before you can start using java-tree-sitter, you need to build a shared library that Java can load using the `build.py` script. The first argument is the output file (-o libjava-tree-sitter), followed by all of the tree-sitter repositories that you want include:
 
-    ./build.py libjava-tree-sitter tree-sitter-css tree-sitter-python ...
+    ./build.py -o libjava-tree-sitter path-to-tree-sitter-css path-to-tree-sitter-python ...
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To add this library to a Gradle project:
 
 ## Building
 
-Before you can start using java-tree-sitter, you need to build a shared library that Java can load using the `build.py` script. The first argument is the output file (-o libjava-tree-sitter), followed by all of the tree-sitter repositories that you want include:
+Before you can start using java-tree-sitter, you need to build a shared library that Java can load using the `build.py` script. The first argument is the output file (_libjava-tree-sitter_ by default), followed by all of the tree-sitter repositories (already downloaded) that you want to include:
 
     ./build.py -o libjava-tree-sitter path-to-tree-sitter-css path-to-tree-sitter-python ...
 

--- a/README.md
+++ b/README.md
@@ -21,79 +21,91 @@ git submodule update --init --recursive
 ## Installing
 
 To add this library to a Gradle project:
-
-    allprojects {
-        repositories {
-            maven { 
-                url 'https://jitpack.io'
-            }
+```java
+allprojects {
+    repositories {
+        maven { 
+            url 'https://jitpack.io'
         }
     }
+}
 
-    dependencies {
-        implementation "com.github.serenadeai:java-tree-sitter:1.1.2"
-    }
+dependencies {
+    implementation "com.github.serenadeai:java-tree-sitter:1.1.2"
+}
+```
 
 ## Building
 
 Before you can start using java-tree-sitter, you need to build a shared library that Java can load using the `build.py` script. The first argument is the output file (_libjava-tree-sitter_ by default), followed by all of the tree-sitter repositories (already downloaded) that you want to include:
 
-    ./build.py -o libjava-tree-sitter path-to-tree-sitter-css path-to-tree-sitter-python ...
+```bash
+./build.py -o libjava-tree-sitter path-to-tree-sitter-css path-to-tree-sitter-python ...
+```
 
 ## Examples
 
 First, load the shared object somewhere in your application:
 
-    public class App {
-      static {
-        // or on a Mac, libjava-tree-sitter.dylib
-        System.load("./path/to/libjava-tree-sitter.so");
-      }
-    }
+```java
+public class App {
+  static {
+    // or on a Mac, libjava-tree-sitter.dylib
+    System.load("./path/to/libjava-tree-sitter.so");
+  }
+}
+```
 
 Then, you can create a `Parser`, set the language, and parse a string:
 
-    try (Parser parser = new Parser()) {
-      parser.setLanguage(Languages.python());
-      try (Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)")) {
-        Node root = tree.getRootNode();
-        assertEquals(1, root.getChildCount());
-        assertEquals("module", root.getType());
-        assertEquals(0, root.getStartByte());
-        assertEquals(44, root.getEndByte());
+```java
+try (Parser parser = new Parser()) {
+  parser.setLanguage(Languages.python());
+  try (Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)")) {
+    Node root = tree.getRootNode();
+    assertEquals(1, root.getChildCount());
+    assertEquals("module", root.getType());
+    assertEquals(0, root.getStartByte());
+    assertEquals(44, root.getEndByte());
 
-        Node function = root.getChild(0);
-        assertEquals("function_definition", function.getType());
-        assertEquals(5, function.getChildCount());
-      }
-    }
+    Node function = root.getChild(0);
+    assertEquals("function_definition", function.getType());
+    assertEquals(5, function.getChildCount());
+  }
+}
+```
 
 For debugging, it can be helpful to see a string of the tree:
 
-    try (Parser parser = new Parser()) {
-      parser.setLanguage(Languages.python());
-      try (Tree tree = parser.parseString("print(\"hi\")")) {
-        assertEquals(
-          "(module (expression_statement (call function: (identifier) arguments: (argument_list (string)))))",
-          tree.getRootNode().getNodeString()
-        );
-      }
-    }
+```
+try (Parser parser = new Parser()) {
+  parser.setLanguage(Languages.python());
+  try (Tree tree = parser.parseString("print(\"hi\")")) {
+    assertEquals(
+      "(module (expression_statement (call function: (identifier) arguments: (argument_list (string)))))",
+      tree.getRootNode().getNodeString()
+    );
+  }
+}
+```
 
 If you're going to be traversing a tree, then you can use the `walk` method, which is much more efficient than the above getters:
 
-    try (Parser parser = new Parser()) {
-      parser.setLanguage(Languages.python());
-      try (Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)")) {
-        try (TreeCursor cursor = tree.getRootNode().walk()) {
-          assertEquals("module", cursor.getCurrentTreeCursorNode().getType());
-          cursor.gotoFirstChild();
-          assertEquals("function_definition", cursor.getCurrentTreeCursorNode().getType());
-          cursor.gotoFirstChild();
-          assertEquals("def", cursor.getCurrentTreeCursorNode().getType());
-          cursor.gotoNextSibling();
-          cursor.gotoParent();
-        }
-      }
+```
+try (Parser parser = new Parser()) {
+  parser.setLanguage(Languages.python());
+  try (Tree tree = parser.parseString("def foo(bar, baz):\n  print(bar)\n  print(baz)")) {
+    try (TreeCursor cursor = tree.getRootNode().walk()) {
+      assertEquals("module", cursor.getCurrentTreeCursorNode().getType());
+      cursor.gotoFirstChild();
+      assertEquals("function_definition", cursor.getCurrentTreeCursorNode().getType());
+      cursor.gotoFirstChild();
+      assertEquals("def", cursor.getCurrentTreeCursorNode().getType());
+      cursor.gotoNextSibling();
+      cursor.gotoParent();
+    }
+  }
+}
+```
 
 For more examples, see the tests in `src/test/java/ai/serenade/treesitter`.

--- a/build.py
+++ b/build.py
@@ -25,10 +25,10 @@ def build(repositories, output_path="libjava-tree-sitter", arch=None, verbose=Fa
         )
 
     os.system(
-        f"make -C {os.path.join(here, 'tree-sitter')} clean {'> /dev/null' if not verbose else ''}"
+        f"make -C \"{os.path.join(here, 'tree-sitter')}\" clean {'> /dev/null' if not verbose else ''}"
     )
     os.system(
-        f"{env} make -C {os.path.join(here, 'tree-sitter')} {'> /dev/null' if not verbose else ''}"
+        f"{env} make -C \"{os.path.join(here, 'tree-sitter')}\" {'> /dev/null' if not verbose else ''}"
     )
 
     cpp = False


### PR DESCRIPTION
I was having some problems running _build.py_ script because my project directory contains spaces:
```bash
make: *** /mnt/c/Users/Ruben: No such file or directory.  Stop.
make: *** /mnt/c/Users/Ruben: No such file or directory.  Stop.
```
After the modifications in this pull request in the `make` command, the issue was solved.

I also had some issues running the script because with the current README the output file "libjava-tree-sitter" was included in the source paths in line:
```bash
source_mtimes = [os.path.getmtime(file)] + [os.path.getmtime(path) for path in source_paths]
```
leading to this error:
```bash
Traceback (most recent call last):
  File "./[build.py](http://build.py/)", line 137, in <module>
    build(args.repositories, args.output, args.arch, args.verbose)
  File "./[build.py](http://build.py/)", line 57, in build
    source_mtimes = [os.path.getmtime(file)] + [os.path.getmtime(path) for path in source_paths]
  File "./[build.py](http://build.py/)", line 57, in <listcomp>
    source_mtimes = [os.path.getmtime(file)] + [os.path.getmtime(path) for path in source_paths]
  File "/usr/lib/python3.8/genericpath.py", line 55, in getmtime
    return os.stat(filename).st_mtime
FileNotFoundError: [Errno 2] No such file or directory: 'libjava-tree-sitter/src/parser.c'
```

By the way, thank you so much for this tool!

Regards,
Rubén.