### PR TITLE
Fix: Build failures on M1 Mac and C-only libraries, memory leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,21 +12,25 @@ repositories {
     mavenCentral()
 }
 
+String sharedObject = "libjava-tree-sitter"
+
 task buildSharedObject {
     inputs.file "lib/ai_serenade_treesitter_Languages.cc"
     inputs.file "lib/ai_serenade_treesitter_Languages.h"
     inputs.file "lib/ai_serenade_treesitter_TreeSitter.cc"
     inputs.file "lib/ai_serenade_treesitter_TreeSitter.h"
-    outputs.file "libjava-tree-sitter.so"
+    outputs.file "${sharedObject}.dylib"
+    outputs.file "${sharedObject}.so"
 
     doLast {
         exec {
-            commandLine "./build.py", "libjava-tree-sitter", "src/test/tree-sitter-python"
+            commandLine "./build.py", "-a", "${System.getProperty("os.arch")}", "src/test/tree-sitter-python", "-o", "${sharedObject}"
         }
     }
 }
 
 clean {
+    delete "libjava-tree-sitter.dylib"
     delete "libjava-tree-sitter.so"
 }
 
@@ -72,5 +76,5 @@ test {
         events "passed", "skipped", "failed"
     }
 
-    environment "JAVA_TREE_SITTER", "${project.projectDir.toString()}/libjava-tree-sitter.so"
+    environment "JAVA_TREE_SITTER", "${project.projectDir.toString()}/libjava-tree-sitter.${System.getProperty("os.name").equalsIgnoreCase("mac os x") ? "dylib" : "so"}"
 }

--- a/build.py
+++ b/build.py
@@ -31,7 +31,6 @@ def build(repositories, output_path="libjava-tree-sitter", arch=None, verbose=Fa
         f"{env} make -C {os.path.join(here, 'tree-sitter')} {'> /dev/null' if not verbose else ''}"
     )
 
-    cpp = False
     source_paths = [
         os.path.join(here, "lib", "ai_serenade_treesitter_TreeSitter.cc"),
         os.path.join(here, "lib", "ai_serenade_treesitter_Languages.cc"),
@@ -44,7 +43,6 @@ def build(repositories, output_path="libjava-tree-sitter", arch=None, verbose=Fa
         scanner_c = os.path.join(src_path, "scanner.c")
         scanner_cc = os.path.join(src_path, "scanner.cc")
         if os.path.exists(scanner_cc):
-            cpp = True
             source_paths.append(scanner_cc)
         elif os.path.exists(scanner_c):
             source_paths.append(scanner_c)
@@ -55,11 +53,10 @@ def build(repositories, output_path="libjava-tree-sitter", arch=None, verbose=Fa
         )
 
     source_mtimes = [os.path.getmtime(__file__)] + [os.path.getmtime(path) for path in source_paths]
-    if cpp:
-        if ctypes.util.find_library("stdc++"):
-            compiler.add_library("stdc++")
-        elif ctypes.util.find_library("c++"):
-            compiler.add_library("c++")
+    if ctypes.util.find_library("stdc++"):
+        compiler.add_library("stdc++")
+    elif ctypes.util.find_library("c++"):
+        compiler.add_library("c++")
 
     output_mtime = os.path.getmtime(output_path) if os.path.exists(output_path) else 0
     if max(source_mtimes) <= output_mtime:

--- a/build.py
+++ b/build.py
@@ -13,6 +13,8 @@ import tempfile
 def build(repositories, output_path="libjava-tree-sitter", arch=None, verbose=False):
     if arch and platform.system() != "Darwin":
         arch = "64" if "64" in arch else "32"
+    if arch and platform.system() == "Darwin":
+        arch = "arm64" if "aarch64" in arch else arch
 
     output_path = f"{output_path}.{'dylib' if platform.system() == 'Darwin' else 'so'}"
     here = os.path.dirname(os.path.realpath(__file__))

--- a/lib/ai_serenade_treesitter_TreeSitter.cc
+++ b/lib/ai_serenade_treesitter_TreeSitter.cc
@@ -202,6 +202,7 @@ Java_ai_serenade_treesitter_TreeSitter_treeCursorCurrentTreeCursorNode(
 
 JNIEXPORT void JNICALL Java_ai_serenade_treesitter_TreeSitter_treeCursorDelete(
     JNIEnv* env, jclass self, jlong cursor) {
+  ts_tree_cursor_delete((TSTreeCursor*)cursor);
   delete (TSTreeCursor*)cursor;
 }
 


### PR DESCRIPTION
This contains three separate fixes that are combined into one PR, let me know if you'd prefer them separated out.

1. I am using an M1 mac, and the build.py was not able to correctly build the shared object for my architecture. I tweaked the gradle build to pass in the architecture, and the build.py to map `aarch64` to `arm64` to compensate. When the `dylib` was built, it became stale and would not get cleaned, and wouldn't get picked up by the tests, so I fixed those as well.
2. I noticed that deleting tree cursors did not call the associated ts_tree_cursor_delete, so I added that call to the JNI shim.
3. If you build with only c-based parser libraries, the `cpp` flag is set to false, despite the JNI shim itself making use of CPP new/delete calls. To fix this, I removed the option for c-only compilation, effectively setting cpp to always true.